### PR TITLE
Make matrixInputs' labels' classes like other Shiny inputs'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinyMatrix
 Title: Shiny Matrix Input Field 
-Version: 0.8.0
+Version: 0.8.1
 Date: 2024-04-10
 Author: Andreas Neudecker
 Maintainer: Andreas Neudecker <andreas.neudecker@inwt-statistics.de>

--- a/R/matrixInput.R
+++ b/R/matrixInput.R
@@ -103,7 +103,7 @@ matrixInput <- function(inputId,
     singleton(tags$head(tags$link(rel = "stylesheet", type = "text/css", href = "shinyMatrix/matrix-input.css"))),
     tags$div(
       class = "form-group shiny-matrix-input-container shiny-input-container-inline shiny-input-container",
-      if (!is.null(label)) tags$label(label, `for` = inputId) else NULL,
+      tags$label(class = c("control-label", if (is.null(label)) "shiny-label-null"), `for` = inputId, label),
       inputField
     )
   )


### PR DESCRIPTION
Themes affect matrixInputs' labels differently from other Shiny inputs'. For example, in the following application the space between the matrixInput and its label is too little.

```R
ui <- shiny::fluidPage(
  theme = bslib::bs_theme(),
  shiny::fluidRow(
    shiny::column(3L, shinyMatrix::matrixInput("matrix", "Label")),
    shiny::column(3L, shiny::textInput("text", "Label")),
    shiny::column(3L, shiny::numericInput("numeric", "Label", 0L)),
    shiny::column(3L, shiny::radioButtons("radio", "Label", letters[seq_len(3L)]))
  )
)

server <- function(input, output, session) {}

shiny::shinyApp(ui, server)
```

<img width="691" height="328" alt="Image" src="https://github.com/user-attachments/assets/88f3eff6-ddc9-46b3-8d24-9e18c19cf168" />

The cause is that matrixInputs' labels do not have the class "control-label". This pull request makes matrixInputs' labels' classes like other Shiny inputs'. The example above becomes

<img width="691" height="328" alt="Image" src="https://github.com/user-attachments/assets/c70eccc8-921d-4b42-8959-700a9b2098dc" />